### PR TITLE
fix(next配置): 优化静态导出配置并修复图片优化设置

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,8 +2,14 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   // 只在构建时启用静态导出，开发时禁用以避免 generateStaticParams 错误
-  ...(process.env.NODE_ENV === 'production' && { output: "export" }),
+  ...(process.env.NODE_ENV === "production" && { output: "export" }),
   trailingSlash: true,
+  // 静态导出时的资源前缀配置
+  ...(process.env.NODE_ENV === "production" && {
+    // 移除 assetPrefix，使用默认的相对路径
+    // assetPrefix: './',
+    basePath: "",
+  }),
   images: {
     // 允许的外部图片域名
     domains: [
@@ -15,8 +21,8 @@ const nextConfig: NextConfig = {
     ],
     // 图片格式优化
     formats: ["image/webp", "image/avif"],
-    // 启用图片优化
-    unoptimized: false,
+    // 静态导出时必须禁用图片优化
+    unoptimized: process.env.NODE_ENV === "production",
     // 图片尺寸配置
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
@@ -28,16 +34,18 @@ const nextConfig: NextConfig = {
   },
   // 压缩配置
   compress: true,
-  // 支持Unicode字符的路由
-  async rewrites() {
-    return {
-      beforeFiles: [],
-      afterFiles: [],
-      fallback: []
-    };
-  },
   // 确保正确处理Unicode字符
-  pageExtensions: ['tsx', 'ts', 'jsx', 'js'],
+  pageExtensions: ["tsx", "ts", "jsx", "js"],
+  // 只在非静态导出模式下启用rewrites
+  ...(process.env.NODE_ENV !== "production" && {
+    async rewrites() {
+      return {
+        beforeFiles: [],
+        afterFiles: [],
+        fallback: [],
+      };
+    },
+  }),
 };
 
 export default nextConfig;


### PR DESCRIPTION
调整静态导出相关配置，移除assetPrefix并明确basePath为空
修复静态导出时的图片优化设置，仅在非生产环境启用
将rewrites配置限制为仅在非静态导出模式下启用
统一字符串引号为双引号