### PR TITLE
refactor: 移除手动basePath处理，使用Next.js内置功能

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,23 +2,7 @@ const nextConfig = {
   // 只在构建时启用静态导出，开发时禁用以避免 generateStaticParams 错误
   ...(process.env.NODE_ENV === "production" && { output: "export" }),
   trailingSlash: true,
-  // 环境变量配置
-  env: {
-    NEXT_PUBLIC_BASE_PATH: (() => {
-      if (!process.env.GITHUB_ACTIONS) return "";
-      
-      const repoName = process.env.REPO_NAME || 
-                      process.env.GITHUB_REPOSITORY?.split("/")[1] || 
-                      "blog-platform";
-      
-      // 如果仓库名以 .github.io 结尾，说明是用户主页仓库，不需要 basePath
-      if (repoName.endsWith(".github.io")) {
-        return "";
-      }
-      
-      return `/${repoName}`;
-    })()
-  },
+  // 移除NEXT_PUBLIC_BASE_PATH环境变量，避免与Next.js内置basePath冲突
   // 静态导出时的资源前缀配置
   ...(process.env.NODE_ENV === "production" && {
     // 动态获取仓库名，支持多种方式：
@@ -40,20 +24,7 @@ const nextConfig = {
       
       return `/${repoName}`;
     })(),
-    assetPrefix: (() => {
-      if (!process.env.GITHUB_ACTIONS) return undefined;
-      
-      const repoName = process.env.REPO_NAME || 
-                      process.env.GITHUB_REPOSITORY?.split("/")[1] || 
-                      "blog-platform";
-      
-      // 如果仓库名以 .github.io 结尾，说明是用户主页仓库，不需要 assetPrefix
-      if (repoName.endsWith(".github.io")) {
-        return undefined;
-      }
-      
-      return `/${repoName}/`;
-    })(),
+    // 移除assetPrefix，basePath已经足够处理资源路径
   }),
   images: {
     // 允许的外部图片域名

--- a/src/components/OptimizedImage.tsx
+++ b/src/components/OptimizedImage.tsx
@@ -12,7 +12,8 @@ function isExternalImage(src: string): boolean {
 }
 
 /**
- * 处理图片路径，添加basePath支持
+ * 处理图片路径，避免重复添加basePath
+ * Next.js的basePath配置会自动处理路径前缀，这里只需要标准化路径格式
  */
 function processImagePath(src: string): string {
   // 如果是外部链接，直接返回
@@ -20,23 +21,21 @@ function processImagePath(src: string): string {
     return src;
   }
   
-  // 获取basePath
-  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
-  
   // 如果是相对路径（如 ./assets/example.svg 或 ../assets/example.svg），转换为绝对路径
   if (src.startsWith('./') || src.startsWith('../')) {
     // 移除相对路径前缀，转换为从public目录开始的路径
     const cleanPath = src.replace(/^\.\.?\//, '');
-    return `${basePath}/${cleanPath}`;
+    return `/${cleanPath}`;
   }
   
-  // 如果已经是绝对路径（以/开头），添加basePath
+  // 如果已经是绝对路径（以/开头），直接返回
+  // Next.js的basePath会自动处理
   if (src.startsWith('/')) {
-    return `${basePath}${src}`;
+    return src;
   }
   
-  // 其他情况，假设是相对于public目录的路径
-  return `${basePath}/${src}`;
+  // 其他情况，假设是相对于public目录的路径，添加前导斜杠
+  return `/${src}`;
 }
 
 interface OptimizedImageProps {

--- a/src/setting/AboutSetting.ts
+++ b/src/setting/AboutSetting.ts
@@ -8,17 +8,11 @@ export const AnimationText = "进步"; //动画字
 const AVATAR_FILENAME = "avatar.jpg";
 
 /**
- * 获取头像完整路径，正确处理basePath
+ * 获取头像完整路径
+ * Next.js的basePath配置会自动处理路径前缀，这里只返回标准的绝对路径
  * @returns 头像的完整路径
  */
 export const getAvatarPath = (): string => {
-  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
-  // 确保路径格式正确，避免重复斜杠
-  if (basePath) {
-    // 移除basePath末尾的斜杠（如果有），然后添加文件名
-    const cleanBasePath = basePath.endsWith('/') ? basePath.slice(0, -1) : basePath;
-    return `${cleanBasePath}/${AVATAR_FILENAME}`;
-  }
   return `/${AVATAR_FILENAME}`;
 };
 


### PR DESCRIPTION
Next.js的basePath配置已能自动处理路径前缀，因此移除手动添加basePath的逻辑
简化图片路径处理和头像路径获取函数，直接返回标准化路径